### PR TITLE
Implement semantic_search in ThinkingAgent

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ It’s designed to be a complete thinking agent with journaling, reflection prom
 - Reflection prompt scoring and strategy evaluation
 - Web search integration using OpenAI `responses` API
 - Simple Tkinter-based GUI interface
+- Semantic search over stored data (e.g., "What thoughts did I record today?")
 
 ## Start
 

--- a/tests/test_thinking_agent.py
+++ b/tests/test_thinking_agent.py
@@ -56,5 +56,20 @@ class ThinkingAgentTests(unittest.TestCase):
         self.mock_client.chat.completions.create.assert_called_once()
         self.assertEqual(response.choices[0].message.content, 'Test response')
 
+    def test_semantic_search(self):
+        # Insert sample thoughts
+        self.agent.execute_sql("INSERT INTO thoughts (content) VALUES ('Thought1')")
+        self.agent.execute_sql("INSERT INTO thoughts (content) VALUES ('Thought2')")
+
+        # Mock OpenAI to return SQL for the semantic search
+        fake_response = MagicMock()
+        fake_choice = MagicMock()
+        fake_choice.message.content = "SELECT content FROM thoughts"
+        fake_response.choices = [fake_choice]
+        self.mock_client.chat.completions.create.return_value = fake_response
+
+        result = self.agent.semantic_search("List all stored thoughts")
+        self.assertEqual(result['rows'], [('Thought1',), ('Thought2',)])
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- enable semantic search over stored thoughts
- expose semantic_search as a tool in the thinking cycle
- test the new semantic search method
- document capability in README

## Testing
- `python -m unittest`

------
https://chatgpt.com/codex/tasks/task_e_6842386dc8648324a30a768a4c21bb41